### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/prakchanraksmey932/76e26f40-4d56-44a5-8ecb-19bdcee599d6/2bca1d93-f05a-47b0-94b6-bd7ab7d59109/_apis/work/boardbadge/bcafd1dd-1240-45fe-a8be-4fe149c2df9c)](https://dev.azure.com/prakchanraksmey932/76e26f40-4d56-44a5-8ecb-19bdcee599d6/_boards/board/t/2bca1d93-f05a-47b0-94b6-bd7ab7d59109/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/prakchanraksmey932/76e26f40-4d56-44a5-8ecb-19bdcee599d6/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.